### PR TITLE
Addded formatted sentence generation

### DIFF
--- a/herodotus/cfg-test.cfg
+++ b/herodotus/cfg-test.cfg
@@ -1,0 +1,3 @@
+S -> 0.5 N V N | 0.5 N V 
+N -> 0.33 "cats" | 0.33 "dogs" | 0.33 "mice"
+V -> 0.25 "chase" | 0.25 "eat" | 0.25 "scare" | 0.25 "see"

--- a/herodotus/herodotus_fast.py
+++ b/herodotus/herodotus_fast.py
@@ -94,6 +94,29 @@ class GrammarTree:
     def generate_from_sentence(self, symbol_names: List[str], max_rec=10, error=False) -> str:
         return ''.join([self.generate_from_symbol(name, max_rec, error) for name in symbol_names])
 
+    def generate_from_format(self, format: str) -> str: 
+        tokens = format.split(' ')
+        reused_symbols = {}
+
+        output = ""
+
+        # Load reused symbols into dictionary
+        for token in tokens:
+            if token in reused_symbols: 
+                continue
+
+            if '|' in token:
+                reused_symbols[token] = self.generate_from_symbol(token.split('|')[0])
+
+        # Construct the actual sentence
+        for token in tokens:
+            if token in reused_symbols:
+                output += reused_symbols[token]
+            else:
+                output += self.generate_from_symbol(token)
+
+        return output
+
 def parse_file(file_path: str) -> GrammarTree:
     tree = GrammarTree()
 
@@ -102,4 +125,11 @@ def parse_file(file_path: str) -> GrammarTree:
             name, expr = parse_line(line)
             tree.symbols[name] = expr
 
-    return tree
+    return tree  
+
+if __name__ == '__main__':
+    tree = parse_file('cfg-test.cfg')
+    sentence = tree.generate_from_format("N|1 V N|1 N|2 N|2")
+
+    print(f"Sentence: {sentence}")
+


### PR DESCRIPTION
You can now generate sentences that reuse parts of speech.

For example:

```
tree.generate_from_format("N|1 V N|1")
```

Will generate a sentence of the form "N V N", but use the same value for "N" since they have the same identifier of 1. In the below example, the generated sentence will only use a maximum of two distinct nouns:

```
tree.generate_from_format("N|1 N|1 N|1 N|2 N|2 N|2")
```

You can write anything you want after the `|` symbol given that it's not a whitespace character to uniquely tag parts of speech